### PR TITLE
Fix Discord link in community section

### DIFF
--- a/src/config/FooterList.ts
+++ b/src/config/FooterList.ts
@@ -50,7 +50,7 @@ export const FooterUrls = {
     target: '_blank' as const,
   },
   reddit: {
-    href: 'https://discord.com/invite/pushchain',
+    href: 'https://www.reddit.com/r/pushprotocol/',
     target: '_blank' as const,
   },
   telegram: {


### PR DESCRIPTION
## Description

Fixed incorrect Reddit link in the Community section of the website. Previously, both the Reddit and Discord icons were linking to the same Discord URL.

## Bug Found

On the push.org homepage, under the Community section, the Reddit icon was incorrectly linking to the Discord URL instead of the Reddit community invite link.

**Before:**
- Reddit icon: Links to Discord ✗ (incorrect)
- Discord icon: Links to Discord ✓

**After:**
- Reddit icon: Links to Reddit ✓(fixed)
- Discord icon: Links to Discord ✓ 

## Changes Made

- Updated the Reddit link in `[FooterList.ts]` to point to the correct Reddit URL
- Verified that both social links now direct to their respective platforms

## Testing

- [x] Verified Reddit link opens the correct Reddit community
- [x] Verified Discord link opens the correct Discord server
- [x] Tested links in both desktop and mobile views
- [x] Confirmed no other social links were affected

## Screenshots

<img width="1440" height="305" alt="Screenshot 2025-10-05 at 03 24 13" src="https://github.com/user-attachments/assets/49088954-afc4-4863-b9ff-171b35f316fa" />

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
